### PR TITLE
Consider checked exceptions.

### DIFF
--- a/src/main/java/org/vibur/objectpool/ConcurrentPool.java
+++ b/src/main/java/org/vibur/objectpool/ConcurrentPool.java
@@ -132,9 +132,9 @@ public class ConcurrentPool<T> implements PoolService<T> {
                 available.offerLast(requireNonNull(poolObjectFactory.create()));
                 createdTotal.incrementAndGet();
             }
-        } catch (RuntimeException | Error e) {
+        } catch (Throwable t) {
             drainCreated();
-            throw e;
+            throw t;
         }
     }
 
@@ -293,9 +293,9 @@ public class ConcurrentPool<T> implements PoolService<T> {
             }
 
             return object;
-        } catch (RuntimeException | Error e) {
+        } catch (Throwable t) {
             recoverInnerState();
-            throw e;
+            throw t;
         }
     }
 
@@ -323,9 +323,9 @@ public class ConcurrentPool<T> implements PoolService<T> {
             }
 
             return ready;
-        } catch (RuntimeException | Error e) {
+        } catch (Throwable t) {
             recoverInnerState();
-            throw e;
+            throw t;
         }
     }
 

--- a/src/main/java/org/vibur/objectpool/util/SamplingPoolReducer.java
+++ b/src/main/java/org/vibur/objectpool/util/SamplingPoolReducer.java
@@ -36,7 +36,7 @@ import static org.vibur.objectpool.util.ArgumentValidation.forbidIllegalArgument
  * the reducer's {@link #start()} method is called, and will be alive until the
  * {@link #terminate()} method is called or until the calling application exits.
  *
- * <p>Note that if a RuntimeException or an Error is thrown by the overridable
+ * <p>Note that if a Throwable is thrown by the overridable
  * {@link #afterReduce(int, int, Throwable)} method hook, it will terminate the
  * SamplingPoolReducer, including the reducer's background daemon thread.
  *
@@ -129,8 +129,8 @@ public class SamplingPoolReducer implements ThreadedPoolReducer {
         Throwable thrown = null;
         try {
             reduced = pool.reduceCreatedBy(reduction, false);
-        } catch (RuntimeException | Error e) {
-            thrown = e;
+        } catch (Throwable t) {
+            thrown = t;
         } finally {
             afterReduce(reduction, reduced, thrown);
         }
@@ -155,13 +155,12 @@ public class SamplingPoolReducer implements ThreadedPoolReducer {
 
     /**
      * An after reduce pool hook. The default implementation will {@code terminate()} this pool reducer
-     * if {@code thrown != null}. Note that if this method throws a RuntimeException or an Error, this
+     * if {@code thrown != null}. Note that if this method throws a Throwable, this
      * will terminate the pool reducer, too.
      *
      * @param reduction the intended reduction number
      * @param reduced the number of objects which were successfully removed/destroyed from the pool
-     * @param thrown a thrown during the pool reduction exception if any, in this case it will be
-     *               a RuntimeException or an Error
+     * @param thrown a thrown during the pool reduction exception if any.
      */
     protected void afterReduce(int reduction, int reduced, Throwable thrown) {
         if (thrown != null) {


### PR DESCRIPTION
The ConcurrentPool needs to perform some cleanups when an exception
occurs in the user-provided implementation of PoolObjectFactory.

PoolObjectFactory methods do not declare any thrown Exceptions,
so it is sufficient to catch Error and RuntimeException in the
ConcurrentPool.

This stops working when one uses this library from kotlin:
It is possible to throw a checked exception from a kotlin implementation
of PoolObjectFactory, and when that happens the cleanups don't occur in
the ConcurrentPool, slowly exhausting slots in the pool and leading to
object starvation.

This commit modifies the catch clauses in the ConcurrentPool and
SamplingPoolReducer to handle any kind of Throwable.